### PR TITLE
add yolo inference

### DIFF
--- a/yolov5/.gitignore
+++ b/yolov5/.gitignore
@@ -249,3 +249,4 @@ crashlytics-build.properties
 fabric.properties
 
 nohup.out
+*.csv

--- a/yolov5/inference.py
+++ b/yolov5/inference.py
@@ -1,0 +1,69 @@
+import argparse
+import os
+import torch
+import cv2
+import pandas as pd
+from PIL import Image
+import pandas as pd
+
+def main(args):
+
+    dir_path = args.label_dir
+    file_list = os.listdir(dir_path)
+    file_list.sort()
+    column_names = ['class','x_center','y_center','width','height','confidence']
+    img_list = os.listdir('/opt/ml/detection/dataset/test')
+    img_list.sort()
+    prediction_strings = []
+    file_names = []
+    
+    for i, name in enumerate(img_list):
+        prediction_string= ''
+        label = name[:-3]+'txt'
+        if label not in file_list:
+            print(name+"is not in file list!!!")
+            prediction_strings.append(prediction_string)
+            file_names.append('test/'+name)
+            continue
+        df = pd.read_csv(os.path.join(dir_path, label),sep=' ',names=column_names)
+        for j in range(len(df)):
+            xmin = (float(df['x_center'][j]) - (float(df['width'][j])/2)) * 1024
+            ymin = (float(df['y_center'][j]) - (float(df['height'][j])/2)) * 1024
+            xmax = (float(df['x_center'][j]) + (float(df['width'][j])/2)) * 1024
+            ymax = (float(df['y_center'][j]) + (float(df['height'][j])/2)) * 1024
+
+            prediction_string += str(df['class'][j]) + ' ' + str(
+                df['confidence'][j]) + ' ' + str(round(xmin,5)) + ' ' + str(
+                    round(ymin,5)) + ' ' + str(round(xmax,5)) +' ' + str(
+                        round(ymax,5)) + ' '
+        
+        prediction_strings.append(prediction_string)
+        file_names.append('test/'+ name)
+        
+
+    submission = pd.DataFrame()
+    submission['PredictionString'] = prediction_strings
+    submission['image_id'] = file_names
+    if args.save_dir is not None:
+        submission.to_csv(os.path.join(args.save_dir,'result.csv'),index=None)
+    submission.to_csv('result.csv',index=None)
+    print(submission.head())
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--label_dir",
+        type=str,
+        default=None
+    )
+    parser.add_argument(
+        "--save_dir",
+        type=str,
+        default=None
+    )
+    args = parser.parse_args()
+
+    if args.label_dir is None:
+        raise NameError('set label directory path')
+    main(args)


### PR DESCRIPTION
yolo inference 추가했습니다.

## Example
inference를 하기전에 annotation txt파일을 생성해주어야합니다.
이 기능은 yolov5에 내장되어있기 때문에 detect.py를 통해 간단하게 수행할 수 있습니다.

`python detect.py --weights {pt_directory} --source ../dataset/test --imgsz 1024 --conf-thres 0.05 --save-txt --save-conf --nosave`


그 후 inference.py 를 통해 csv 파일을 생성 할 수 있습니다. save_dir 을 지정해주지 않으면 yolov5 디렉토리에 저장되고 result.csv 이름으로 저장됩니다.

`python inference.py --label_dir runs/detect/exp/labels` 